### PR TITLE
Add python3.11-cryptography for use with default MySQL

### DIFF
--- a/packages
+++ b/packages
@@ -16,6 +16,7 @@ python3.11-idna
 python3.11-lxml
 python3.11-ply
 python3.11-PyMySQL
+python3.11-cryptography
 
 # PHP
 php-cli


### PR DESCRIPTION
The package python3.11-cryptography is needed to be able to connect to MySQL databases.